### PR TITLE
Correct channel order

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: pangolin
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - biopython=1.74


### PR DESCRIPTION
The conda-forge channel needs to have higher prio than bioconda. 