### PR TITLE
Adding automated publishing to Pypi upon release with Github actions

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -14,7 +14,7 @@ jobs:
           uses: actions/setup-python@v1
           with:
             python-version: 3.7
-        - name: Build sourcepredict
+        - name: build pangolin
           run: |
             pip install wheel
             python setup.py sdist bdist_wheel

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,24 @@
+name: publish_pypi
+
+on: 
+  release:
+    types: [published, edited]
+
+jobs:
+    build-and-publish:
+      name: Build and publish Python 🐍 distributions 📦 to PyPI
+      runs-on: ubuntu-18.04
+      steps:
+        - uses: actions/checkout@v1
+        - name: Setup Python 3.7
+          uses: actions/setup-python@v1
+          with:
+            python-version: 3.7
+        - name: Build sourcepredict
+          run: |
+            pip install wheel
+            python setup.py sdist bdist_wheel
+        - name: Publish distribution 📦 to PyPI
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Using the Github action [pypi-publish](https://github.com/marketplace/actions/pypi-publish) will build and publish the Pangolin python package to Pypi upon the creation or modification of a new release on Github.

The only thing left for the maintainers of this repository (@aineniamh ?, @rambaut ?) is to add a secrets named `PYPI_TOKEN`, with the Pypi API token, here: [github.com/hCoV-2019/pangolin/settings/secrets](https://github.com/hCoV-2019/pangolin/settings/secrets).
You can get an API token for Pypi here: [pypi.org/manage/account](https://pypi.org/manage/account/).